### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/pramshy/b0a51986-8ed3-4eb8-8c4a-e74d826500b1/0eb8e272-54d1-4a19-9682-86a0b5acb5ab/_apis/work/boardbadge/b563c994-379b-4138-8ac1-629650cc8d33)](https://dev.azure.com/pramshy/b0a51986-8ed3-4eb8-8c4a-e74d826500b1/_boards/board/t/0eb8e272-54d1-4a19-9682-86a0b5acb5ab/Microsoft.RequirementCategory)
 # javaindepth
 OOPs and OOAD concepts with java, fast java algo tricks, new java features


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/pramshy/b0a51986-8ed3-4eb8-8c4a-e74d826500b1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.